### PR TITLE
use standard perl tools

### DIFF
--- a/share/extra-files/relocation.pl.bat
+++ b/share/extra-files/relocation.pl.bat
@@ -124,9 +124,7 @@ sub read_file {
       warn "Can't open '$path': $!" if not $quiet;
       return undef;
     }
-    my $content = '';
-    while ($file->sysread(my $buffer, 131072, 0)) { $content .= $buffer }
-    return $content;
+    return do { local $/; <$file> };
 }
 
 sub write_file {


### PR DESCRIPTION
Why to use low-level sysread()? Perl already has buffered reading.
http://stackoverflow.com/questions/206661/what-is-the-best-way-to-slurp-a-file-into-a-string-in-perl
https://rt.cpan.org/Public/Bug/Display.html?id=83126
https://rt.perl.org/Public/Bug/Display.html?id=121870
