### PR TITLE
use TAP::Harness::Restricted to skip only some tests

### DIFF
--- a/share/32bit-5.24.1.1.pp
+++ b/share/32bit-5.24.1.1.pp
@@ -100,6 +100,7 @@
     {
         plugin => 'Perl::Dist::Strawberry::Step::InstallModules',
         modules => [
+            'TAP::Harness::Restricted', #to be able to only some tests
             # IPC related
             { module=>'IPC-Run', skiptest=>1 }, #XXX-TODO trouble with 'Terminating on signal SIGBREAK(21)' https://metacpan.org/release/IPC-Run
             { module=>'IPC-System-Simple', ignore_testfailure=>1 }, #XXX-TODO t/07_taint.t fails https://metacpan.org/release/IPC-System-Simple
@@ -172,7 +173,7 @@
             { module=>'WWW::Mechanize', skiptest=>1 }, # tests hang
 
             # data/text processing
-            { module=>'IO::Stringy', ignore_testfailure=>1 },
+            { module=>'IO::Stringy', env=>{ 'HARNESS_SUBCLASS'=>'TAP::Harness::Restricted', 'HARNESS_SKIP'=>'t/IO_InnerFile.t' } }, #https://rt.cpan.org/Public/Bug/Display.html?id=103895
             qw/ Text-Diff Text-Patch Text::CSV Text::CSV_XS Tie::Array::CSV Excel::Writer::XLSX Spreadsheet::ParseXLSX Spreadsheet::WriteExcel Spreadsheet::ParseExcel /,
 
             # database stuff


### PR DESCRIPTION
Skipping all tests when there is error only in one test can create problems in future, if error will appear in module or its dependency.