### PR TITLE
include my_documents in the portable.perl files so toolchain will work

### DIFF
--- a/share/portable/portable.perl.32
+++ b/share/portable/portable.perl.32
@@ -19,6 +19,7 @@ minicpan:
 HomeDir:
   my_home: data
   my_data: data
+  my_documents: data
 Config:
   archlib: perl/lib
   archlibexp: perl/lib

--- a/share/portable/portable.perl.32-NEW
+++ b/share/portable/portable.perl.32-NEW
@@ -19,6 +19,7 @@ minicpan:
 HomeDir:
   my_home: data
   my_data: data
+  my_documents: data
 Config:
   archlib: perl/lib
   archlibexp: perl/lib

--- a/share/portable/portable.perl.473.32
+++ b/share/portable/portable.perl.473.32
@@ -19,6 +19,7 @@ minicpan:
 HomeDir:
   my_home: data
   my_data: data
+  my_documents: data
 Config:
   archlib: perl/lib
   archlibexp: perl/lib

--- a/share/portable/portable.perl.473.64
+++ b/share/portable/portable.perl.473.64
@@ -19,6 +19,7 @@ minicpan:
 HomeDir:
   my_home: data
   my_data: data
+  my_documents: data
 Config:
   archlib: perl/lib
   archlibexp: perl/lib

--- a/share/portable/portable.perl.64
+++ b/share/portable/portable.perl.64
@@ -19,6 +19,7 @@ minicpan:
 HomeDir:
   my_home: data
   my_data: data
+  my_documents: data
 Config:
   archlib: perl/lib
   archlibexp: perl/lib

--- a/share/portable/portable.perl.tt
+++ b/share/portable/portable.perl.tt
@@ -19,6 +19,7 @@ minicpan:
 HomeDir:
   my_home: data
   my_data: data
+  my_documents: data
 Config:
   archlib: perl/lib
   archlibexp: perl/lib


### PR DESCRIPTION
Various toolchain things expect my_documents to work, particularly CPANTesters-related things, so this is a minimal effort change to keep them functional.