### PR TITLE
set syntax highlighting for files when viewed on github.com

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+*.pm linguist-language=Perl
+*.pp linguist-language=Perl
+*.t linguist-language=Perl
+*.pl linguist-language=Perl
+*.h linguist-language=C


### PR DESCRIPTION
The pp files are perl so we might as well highlight them as such when viewed on github.com.  

The others might not be needed but shouldn't hurt.