### PR TITLE
git ignore, module names and INST_VER

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ MYMETA.yml
 MANIFEST
 /META.json
 /MYMETA.json
+
+*.iml
+/.idea/

--- a/lib/Perl/Dist/Strawberry/Step.pm
+++ b/lib/Perl/Dist/Strawberry/Step.pm
@@ -420,9 +420,9 @@ sub _install_module {
   $shortname =~ s|[\\/]+|_|g;
   $shortname =~ s/\.(tar\.gz|tar\.bz2|zip|tar|gz)$//;
   my $script_pl = $self->boss->resolve_name("<dist_sharedir>/utils/CPANMINUS_install_module.pl");
-  my $log         = catfile($self->global->{debug_dir}, "mod_install_".$now."_".$shortname.".log.txt");
-  my $dumper_file = catfile($self->global->{debug_dir}, "mod_install_".$now."_".$shortname.".list.dumper.txt");
-  my $nstore_file = catfile($self->global->{debug_dir}, "mod_install_".$now."_".$shortname.".list.nstore.txt");
+  my $log         = catfile($self->global->{debug_dir}, "mod_install_${shortname}_${now}.log.txt");
+  my $dumper_file = catfile($self->global->{debug_dir}, "mod_install_${shortname}_${now}.list.dumper.txt");
+  my $nstore_file = catfile($self->global->{debug_dir}, "mod_install_${shortname}_${now}.list.nstore.txt");
 
   my $env = {
     PERL_MM_USE_DEFAULT=>1, AUTOMATED_TESTING=>undef, RELEASE_TESTING=>undef,

--- a/lib/Perl/Dist/Strawberry/Step/InstallPerlCore.pm
+++ b/lib/Perl/Dist/Strawberry/Step/InstallPerlCore.pm
@@ -52,8 +52,12 @@ sub run {
   }
   die "ERROR: cannot detect perl-src dir" unless $perlsrc;
  
-  #get verion string - e.g. '5.15.9'
-  my ($version) = grep { /INST_VER/ } read_file(catfile($unpack_to, $perlsrc, qw/win32 makefile.mk/));
+  #get version string - e.g. '5.15.9'
+  my $file_to_check = catfile($unpack_to, $perlsrc, qw/win32 makefile.mk/);
+  if (!-e $file_to_check) {
+    $file_to_check = catfile($unpack_to, $perlsrc, qw/win32 GNUMakefile/);
+  }
+  my ($version) = grep { /INST_VER/ } read_file($file_to_check);
   $version =~ s/^.*?(5\..*?)[\r\n]*$/$1/;
 
   # some handy variables


### PR DESCRIPTION
These are three unrelated commits but I figured one PR is easier than three.  I can always subdivide and submit separately if needed.  

Commit 1 avoids committing intellij config files to the repo.  

Commit 2 reorders the module logs to be more autocomplete friendly, e.g. ```mod_install_Some_Module_1677398882.log.txt``` instead of ```mod_install_1677398882_Some_Module.log.txt```.

Commit 3 updates the code to check ```win32\GNUMakwfile``` for the INST_VER value given ```win32\makefile.mk``` is not distributed with perl 5.34 and later.  (fixes #54)
