### PR TITLE
Strawberry.pm: Allow for backslashes in file URLs when getting basenames

### DIFF
--- a/lib/Perl/Dist/Strawberry.pm
+++ b/lib/Perl/Dist/Strawberry.pm
@@ -452,7 +452,9 @@ sub mirror_url {
 
   # Check if the file already is downloaded.
   my $file = $url;
-  $file =~ s|^.+\/||;# Delete anything before the last forward slash, leaves only the filename.
+  # Delete anything before the last slash, leaves only the filename.
+  # The backward slashes allow for file URLs.
+  $file =~ s|^.+[/\\]||;
   my $target = catfile( $dir, $file );
 
   return $target if $self->global->{offline} and -f $target;


### PR DESCRIPTION
File URLs are converted to backslashes somewhere along the line so this is needed to make them usable.