### PR TITLE
Update portableshell.bat to return exit code from Perl invocations.

### DIFF
--- a/share/portable/portableshell.bat
+++ b/share/portable/portableshell.bat
@@ -14,8 +14,19 @@ set PERL_MB_OPT=
 
 if "%1" == "/SETENV" goto END
 
-if not "%1" == "" "%~dp0perl\bin\perl.exe" %* & goto ENDLOCAL
+if "%1" == "" goto INTERACTIVE
 
+REM For non-interactive invocations of this batch file, run Perl with all
+REM provided argument and return its exit code.  Clear the ERRORLEVEL
+REM variable in our local environment to ensure our "exit /b" statement
+REM returns the error level from Perl even if there is already an ERRORLEVEL
+REM variable in the environment:
+REM   https://devblogs.microsoft.com/oldnewthing/20080926-00
+set ERRORLEVEL=
+"%~dp0perl\bin\perl.exe" %*
+exit /b %ERRORLEVEL%
+
+:INTERACTIVE
 echo ----------------------------------------------
 echo  Welcome to Strawberry Perl Portable Edition!
 echo  * URL - http://www.strawberryperl.com/

--- a/share/portable/portableshell.pdl.bat
+++ b/share/portable/portableshell.pdl.bat
@@ -17,8 +17,19 @@ set PERL_MB_OPT=
 
 if "%1" == "/SETENV" goto END
 
-if not "%1" == "" "%~dp0perl\bin\perl.exe" %* & goto ENDLOCAL
+if "%1" == "" goto INTERACTIVE
 
+REM For non-interactive invocations of this batch file, run Perl with all
+REM provided argument and return its exit code.  Clear the ERRORLEVEL
+REM variable in our local environment to ensure our "exit /b" statement
+REM returns the error level from Perl even if there is already an ERRORLEVEL
+REM variable in the environment:
+REM   https://devblogs.microsoft.com/oldnewthing/20080926-00
+set ERRORLEVEL=
+"%~dp0perl\bin\perl.exe" %*
+exit /b %ERRORLEVEL%
+
+:INTERACTIVE
 echo ----------------------------------------------
 echo  Welcome to Strawberry Perl PDL Edition!
 echo  * URL - https://strawberryperl.com + http://pdl.perl.org


### PR DESCRIPTION
This change modifies the non-interactive path in portableshell.bat (where it invokes Perl with all provided arguments) to return the exit code from the Perl process via "exit /b %ERRORLEVEL%" to the caller.

Prior to this change, using "portableshell.bat" in place of "perl.exe" to run commands like:

  portableshell.bat script.pl arg1 arg2

would return with an exit code of zero, which is problematic if you want to use the batch file in a makefile recipe or in some other environment where you need to take additional actions based on the Perl script's exit code.