### PR TITLE
Update util calls for changed arg requirements

### DIFF
--- a/lib/Perl/Dist/Strawberry/Step.pm
+++ b/lib/Perl/Dist/Strawberry/Step.pm
@@ -465,18 +465,22 @@ sub _install_module {
   $args{module} = $self->boss->resolve_name($args{module});
   $args{module} =~ s|\\|/|g; # cpanm dislikes backslashes
 
-  my %params = ( '-url' => $self->global->{cpan_url}, '-install_to' => 'vendor', '-module' => $args{module} ); #XXX-TODO multiple modules?
-  $params{'-out_dumper'}         = $dumper_file if $dumper_file;
-  $params{'-out_nstore'}         = $nstore_file if $nstore_file;
-  $params{'-install_to'}         = $args{install_to}         if defined $args{install_to};
-  $params{'-verbose'}            = $args{verbose}            if defined $args{verbose};
-  $params{'-skiptest'}           = $args{skiptest}           if defined $args{skiptest};
-  $params{'-ignore_testfailure'} = $args{ignore_testfailure} if defined $args{ignore_testfailure};
-  $params{'-ignore_uptodate'}    = $args{ignore_uptodate}    if defined $args{ignore_uptodate};
-  $params{'-prereqs'}            = $args{prereqs}            if defined $args{prereqs};
-  $params{'-interactivity'}      = $args{interactivity}      if defined $args{interactivity};
-  $params{'-makefilepl_param'}   = $args{makefilepl_param}   if defined $args{makefilepl_param}; #XXX-TODO multiple args?
-  $params{'-buildpl_param'}      = $args{buildpl_param}      if defined $args{buildpl_param};    #XXX-TODO multiple args?
+  my %params = ( 
+    '--url' => $self->global->{cpan_url}, 
+    '--install_to' => 'vendor', 
+    '--module' => $args{module}, #XXX-TODO multiple modules?
+  ); 
+  $params{'--out_dumper'}         = $dumper_file if $dumper_file;
+  $params{'--out_nstore'}         = $nstore_file if $nstore_file;
+  $params{'--install_to'}         = $args{install_to}         if defined $args{install_to};
+  $params{'--verbose'}            = $args{verbose}            if defined $args{verbose};
+  $params{'--skiptest'}           = $args{skiptest}           if defined $args{skiptest};
+  $params{'--ignore_testfailure'} = $args{ignore_testfailure} if defined $args{ignore_testfailure};
+  $params{'--ignore_uptodate'}    = $args{ignore_uptodate}    if defined $args{ignore_uptodate};
+  $params{'--prereqs'}            = $args{prereqs}            if defined $args{prereqs};
+  $params{'--interactivity'}      = $args{interactivity}      if defined $args{interactivity};
+  $params{'--makefilepl_param'}   = $args{makefilepl_param}   if defined $args{makefilepl_param}; #XXX-TODO multiple args?
+  $params{'--buildpl_param'}      = $args{buildpl_param}      if defined $args{buildpl_param};    #XXX-TODO multiple args?
 
   # handle global test skip
   $params{'-skiptest'} = 1 unless $self->global->{test_modules};

--- a/lib/Perl/Dist/Strawberry/Step/UninstallModules.pm
+++ b/lib/Perl/Dist/Strawberry/Step/UninstallModules.pm
@@ -77,9 +77,9 @@ sub _uninstall_module {
   # resolve macros in module name
   $args{module} = $self->boss->resolve_name($args{module});
   my %params;
-  $params{-url}     = $self->global->{cpan_url};
-  $params{-module}  = $args{module}; #XXX-TODO multiple modules?
-  $params{-verbose} = $args{verbose} if defined $args{verbose};
+  $params{--url}     = $self->global->{cpan_url};
+  $params{--module}  = $args{module}; #XXX-TODO multiple modules?
+  $params{--verbose} = $args{verbose} if defined $args{verbose};
   # Execute the module uninstall script
   my $rv = $self->execute_special(['perl', $script_pl, %params], $log, $log, $env);
   unless(defined $rv && $rv == 0) {

--- a/lib/Perl/Dist/Strawberry/Step/UpgradeCpanModules.pm
+++ b/lib/Perl/Dist/Strawberry/Step/UpgradeCpanModules.pm
@@ -88,9 +88,9 @@ sub _get_cpan_upgrades_list {
   my $nstore_file = catfile($self->global->{debug_dir}, "cpan_upgrade.nstore.txt");
 
   # Execute the CPAN upgrade script.
-  my $rv = $self->execute_special(['perl', $script_pl, '-url', $self->global->{cpan_url},
-                                                   '-out_nstore', $nstore_file,
-                                                   '-out_dumper', $dumper_file ], $log);
+  my $rv = $self->execute_special(['perl', $script_pl, '--url', $self->global->{cpan_url},
+                                                   '--out_nstore', $nstore_file,
+                                                   '--out_dumper', $dumper_file ], $log);
 
   die "ERROR: exec '$script_pl' failed" unless defined $rv && $rv == 0;
   die "ERROR: missing file '$nstore_file'" unless -f $nstore_file;


### PR DESCRIPTION
The cpanm etc utilities now expect arguments that satisfy gnu_getopt and no_ignore_case from Getopt::Long.

This means args must be of the form "--arg" instead of "-arg".

Fixes #179 
