### PR TITLE
Fully disable checks when $ENV{SKIP_MSI_STEP} is true

### DIFF
--- a/lib/Perl/Dist/Strawberry.pm
+++ b/lib/Perl/Dist/Strawberry.pm
@@ -119,11 +119,21 @@ sub do_job {
 
   #check
   $self->message(0, "starting global check");
-  $i = 0;
-  for (@{$self->{build_job_steps}}) {    
-    $self->message(1, "checking [step:$i] ".ref($_));
-    $_->check unless $_->{data}->{done} || $_->{config}->{disable}; # dies on error
+  $i = -1;
+  STEP:
+  for my $step (@{$self->{build_job_steps}}) {    
     $i++;
+    my $msg = "checking [step:$i] ".ref($_);
+    if ($step->{config}->{disable}) {
+        $msg .= " (disabled, skipping check)";
+        $self->message(1, $msg);
+        next STEP;
+    }
+    $self->message(1, $msg);
+    
+    next STEP if $step->{data}->{done};
+    
+    $step->check; # dies on error
   }; 
 
   #run

--- a/lib/Perl/Dist/Strawberry.pm
+++ b/lib/Perl/Dist/Strawberry.pm
@@ -84,7 +84,7 @@ sub parse_options {
   $self->global->{image_dir_quotemeta} = $idq;
   $self->global->{image_dir_url}       = "file:///$idu";
   
-  if (defined $self->global->{wixbin_dir}) {
+  if (defined $self->global->{wixbin_dir} && !$ENV{SKIP_MSI_STEP}) {
     my $d = $self->global->{wixbin_dir};
     unless (-f "$d/candle.exe" && -f "$d/light.exe") {
       die "ERROR: invalid wixbin_dir '$d' (candle.exe+light.exe not found)\n";
@@ -122,7 +122,7 @@ sub do_job {
   $i = 0;
   for (@{$self->{build_job_steps}}) {    
     $self->message(1, "checking [step:$i] ".ref($_));
-    $_->check unless $_->{data}->{done}; # dies on error
+    $_->check unless $_->{data}->{done} || $_->{config}->{disable}; # dies on error
     $i++;
   }; 
 


### PR DESCRIPTION
Otherwise the system kept checking for the wix dirs even though they are not needed.

Will un-draft the PR when my local test build completes.  [Edit - done now]

It might also be useful to add more logging when a check is skipped.  [Edit - done now]

Fixes #172 