### PR TITLE
Add 'portableshell.ps1'

### DIFF
--- a/share/portable/portableshell.ps1
+++ b/share/portable/portableshell.ps1
@@ -1,0 +1,88 @@
+# Strawberry Perl Portable Shell - PowerShell Edition
+
+# globals used by setup/teardown
+$strawberry_perl_old_path = $env:Path
+$strawberry_perl_old_env  = @{}
+$strawberry_perl_env_keys = @(
+    'TERM'
+    'PERL_JSON_BACKEND'
+    'PERL_YAML_BACKEND'
+    'PERL5LIB'
+    'PERL5OPT'
+    'PERL_MM_OPT'
+    'PERL_MB_OPT'
+)
+
+function strawberry_perl_setup_environment {
+    foreach ($key in $global:strawberry_perl_env_keys) {
+        if (Test-Path "env:$key") {
+            $global:strawberry_perl_old_env[$key] = [Environment]::GetEnvironmentVariable($key)
+        }
+    }
+    foreach ($key in $global:strawberry_perl_env_keys) {
+        Set-Item -Path "env:$key" -Value ""
+    }
+
+    $path_pfx = $PSScriptRoot + "\perl\site\bin;" + $PSScriptRoot + "\perl\bin;" + $PSScriptRoot + "\c\bin;"
+    $env:Path = $path_pfx + $env:Path
+}
+
+function strawberry_perl_teardown_environment {
+    $env:Path = $global:strawberry_perl_old_path
+    foreach ($key in $global:strawberry_perl_env_keys) {
+        if ($global:strawberry_perl_old_env.ContainsKey($key)) {
+            [Environment]::SetEnvironmentVariable($key, $global:strawberry_perl_old_env[$key])
+        } else {
+            [Environment]::SetEnvironmentVariable($key, $null)  # actually unsets it
+        }
+    }
+}
+
+# only set the env
+if ($args[0] -eq "--setenv") {
+    strawberry_perl_setup_environment
+    Write-Host "Strawberry-Perl environment vars set for the session"
+    return
+}
+
+# When creating an interactive session,
+#  the newly spawned Powershell sources portableshell.ps1
+#  to set up the environment.
+# This is the recursion guard portion
+if ($MyInvocation.InvocationName -eq '.') {
+    strawberry_perl_setup_environment
+
+    Write-Host "----------------------------------------------"
+    Write-Host "Welcome to Strawberry Perl Portable Edition!"
+    Write-Host "* URL - http://www.strawberryperl.com/"
+    Write-Host "* see README.TXT for more info"
+    Write-Host "----------------------------------------------"
+
+    perl -MConfig -e 'printf(qq{Perl executable: %s\nPerl version   : %vd / $Config{archname}\n\n}, $^X, $^V)'
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "FATAL ERROR: 'perl' does not work; check if your strawberry pack is complete!"
+        exit
+    }
+
+    return
+}
+
+if ($args.Count -gt 0) { # pass to perl
+    try {
+        strawberry_perl_setup_environment
+
+        perl $args
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "FATAL ERROR: perl exited with code $LASTEXITCODE"
+        }
+    } finally {
+        strawberry_perl_teardown_environment
+    }
+    return
+} else { # interactive run
+    # The user could be running either powershell.exe (PS v5) or pwsh.exe (PS v7).
+    # He would expect to keep his shell version.
+    $exe = (Get-Process -Id $PID).Path
+    & $exe -NoExit -Command ". '$PSCommandPath'"
+}


### PR DESCRIPTION
This is a Powershell version of the `portableshell.bat`.

I've seen https://github.com/StrawberryPerl/Perl-Dist-Strawberry/issues/52,
I took that into consideration.
The dot source recursion trick (see in the script) makes it such that
the environment is set up after profile is sourced,
consequently, the `psperl` problem or anything alike
can never come up.

Now, I'm pretty sure the script needs to be addressed somewhere in a pipeline,
please help me out with that.

I would also like to note that while I'm generally confident about this script,
I have been using it for one day.
You way want to wait a week or so before merging so it may get some real life testing.
Assuming you are on board with that, I'll ping you then (assuming I don't lose my life in a halt and catch fire), how about that?